### PR TITLE
Icebitsy pmods

### DIFF
--- a/amaranth_boards/icebreaker_bitsy.py
+++ b/amaranth_boards/icebreaker_bitsy.py
@@ -35,9 +35,11 @@ class ICEBreakerBitsyPlatform(LatticeICE40Platform):
     ]
     connectors = [
         Connector("edge", 0,  # Pins bottom P0 - P12,
-            "47 44 48 45  4  3  9 10 11 12 21 13"
-            "20 25 23 27 26 28 31 32 34 36 43 46"
-        )
+            {"0":"47",  "1":"44",  "2":"48",  "3":"45",  "4": "4",  "5": "3",
+             "6": "9",  "7":"10",  "8":"11",  "9":"12", "10":"21", "11":"13",
+            "12":"20", "13":"25", "14":"23", "15":"27", "16":"26", "17":"28",
+            "18":"31", "19":"32", "20":"34", "21":"36", "22":"43", "23":"46"}
+        ),
     ]
 
     def toolchain_program(self, products, name, run_vid=None, run_pid=None, dfu_vid="1d50", dfu_pid="6146", reset=True):

--- a/amaranth_boards/icebreaker_bitsy.py
+++ b/amaranth_boards/icebreaker_bitsy.py
@@ -40,6 +40,9 @@ class ICEBreakerBitsyPlatform(LatticeICE40Platform):
             "12":"20", "13":"25", "14":"23", "15":"27", "16":"26", "17":"28",
             "18":"31", "19":"32", "20":"34", "21":"36", "22":"43", "23":"46"}
         ),
+        Connector("pmod", 1, " 0  2  4  6 - -  1  3  5  7 - -", conn=("edge", "0")), # PMOD 1
+        Connector("pmod", 2, "22 19 16 17 - - 21 18 15 20 - -", conn=("edge", "0")), # PMOD 2
+        Connector("pmod", 3, "14  9 11  8 - - 13 10 12 23 - -", conn=("edge", "0"))  # PMOD 3
     ]
 
     def toolchain_program(self, products, name, run_vid=None, run_pid=None, dfu_vid="1d50", dfu_pid="6146", reset=True):


### PR DESCRIPTION
This corrects the indexing of the edge pins and adds Pmod connectors that are "stacked" onto the edge connector.

The Pmod breakout is a base board that is available for the iCEBreaker-Bitsy and provides a standardized breakout of the edge pins into Pmods. The Pmod index starts at 1 to match the PCB silkscreen.