### PR TITLE
Test module that configure a given pin of a connector as output, and makes it blink -plug a LED on it-

### DIFF
--- a/amaranth_boards/test/blinky_gpio.py
+++ b/amaranth_boards/test/blinky_gpio.py
@@ -1,0 +1,66 @@
+### main deps
+from amaranth import *
+from amaranth.build import Platform, Resource, Pins
+#from amaranth_boards.resources import Pins
+from typing import List, Dict, Tuple, Optional
+
+__all__ = ["BlinkyGpio"]
+
+class BlinkyGpio(Elaboratable):
+    """A one second cycle, 50% duty to drive a led on a target gpio of a connector.
+    
+    Striped down version of the amaranth-board 'blinky'."""
+
+    def __init__(self, connectorName:str, connectorIndex:int, pinIndex:int, attrs = None):
+        """Store the parameters for the elaboration
+
+        Args:
+            connectorName (str): The connector name
+            connectorIndex (int): The connector name
+            pinIndex (int): The index of the pin to use
+            attrs (Attrs, optional): The attributes to setup the pin, platform dependant. Defaults to None.
+        """
+        self.connectorName = connectorName
+        self.connectorIndex = connectorIndex
+        self.targetPinIndex = pinIndex
+        self.attrs = attrs
+
+    def setup(self, platform):
+        """Demonstrate how to setup a pin of the platform
+
+        Args:
+            platform (Platform): the platform to update.
+        """
+        # retrieve the targeted pin
+        pin_name = platform.connectors[self.connectorName, self.connectorIndex].mapping[str(self.targetPinIndex)]
+        print(f"pin name = {pin_name}")
+
+        # setup pin as resource
+        res = Resource("my_gpio",0,Pins(pin_name, dir="o"))
+        if self.attrs is not None:
+            res.attrs.update(self.attrs)
+        
+        # append resource into platform
+        platform.add_resources([res])
+
+    def elaborate(self, platform):
+        m = Module()
+
+        # -- -- configure the targeted pin as "my_gpio" index 0
+        self.setup(platform)
+
+        # -- -- make my_gpio[0] blink
+        target = platform.request("my_gpio",0)
+
+        clk_freq = platform.default_clk_frequency
+        timer = Signal(range(int(clk_freq//2)), reset=int(clk_freq//2) - 1)
+        blink = Signal(reset=1)
+
+        m.d.comb += target.eq(blink)
+        with m.If(timer == 0):
+            m.d.sync += timer.eq(timer.reset)
+            m.d.sync += blink.eq(~blink)
+        with m.Else():
+            m.d.sync += timer.eq(timer - 1)
+
+        return m 


### PR DESCRIPTION
followup of [my comment](https://github.com/amaranth-lang/amaranth-boards/issues/128#issuecomment-1250138554) for #128 

typical (taken from https://github.com/sporniket/amaranth_sandbox/tree/feat-colorlight-connector-experiment/board--colorlight-i9 )

```python
# imports for writing the new platform
import os
import subprocess

from amaranth.build import *
from amaranth.vendor.lattice_ecp5 import *
from amaranth_boards.resources import *  # from .resources import *

# imports for writing the test
from blinky import *
from blinky_gpio import *

# === the platform ===
class Colorlight_I9_V7_2_Platform(LatticeECP5Platform):
    """See board info at https://github.com/wuxx/Colorlight-FPGA-Projects/blob/master/colorlight_i9_v7.2.md"""

    device = "LFE5U-45F"
    package = "BG381"
    speed = "6"
    default_clk = "clk25"

    resources = [
        Resource(
            "clk25", 0, Pins("P3", dir="i"), Clock(25e6), Attrs(IO_TYPE="LVCMOS33")
        ),
        *LEDResources(
            pins="L2", attrs=Attrs(IO_TYPE="LVCMOS33", DRIVE="4")
        ),  # the sample use LVCMOS25, but this pins is also accessible out of the board
    ]

    # no connectors for now
    connectors = [
        # 'P[2..6] connectors, 2x15 pins ; pins are listed row by row ; meaning first 2x6 pmod is from pin 1 to 12, second 2x6 pmod is from pin 18
        Connector(
            "p",
            2,
            "- - - - K18  L2 T18 C18 R17 R18 M17 P17 " #first pmod
            "U18 T17 - - P18 U17 " 
            "- - - - N18 N17 L20 M18 K20 L18 G20 J20" # second pmod
        ),
    ]

    @property
    def required_tools(self):
        return super().required_tools + ["openFPGALoader"]

    def toolchain_prepare(self, fragment, name, **kwargs):
        overrides = dict(ecppack_opts="--compress")
        overrides.update(kwargs)
        return super().toolchain_prepare(fragment, name, **overrides)

    def toolchain_program(self, products, name):
        tool = os.environ.get("OPENFPGALOADER", "openFPGALoader")
        with products.extract("{}.bit".format(name)) as bitstream_filename:
            subprocess.check_call([tool, "-c", "cmsisdap", "-m", bitstream_filename])

# === the test ===

def askContinue():
    action = input("Continue ? (y/n) :")
    if action == "n":
        print("Bye.")
        exit()

if __name__ == "__main__":
    print("========================[ START testing onboard LED ]============================")
    Colorlight_I9_V7_2_Platform().build(Blinky(), do_program=True)
    askContinue()

    # list of addressable pins on the first row
    row_one = (5,7,9,11,13,17,23,25,27,29)
    row_two = (6,8,10,12,14,18,24,26,28,30)

    conn_index = 2 # provision for future loop
    print(f"========================[START testing connector 'p'#{conn_index} -- row 1]============================")
    print(f"INSTALL test rig on first row of connector {conn_index}")
    askContinue()
    for pin in row_one:
        print(f"------------------------> Pin Under Test : #{pin}")
        Colorlight_I9_V7_2_Platform().build(BlinkyGpio("p",2,pin), do_program=True)
        askContinue()

    print(f"========================[START testing connector 'p'#{conn_index} -- row 2]============================")
    print(f"INSTALL test rig on second row of connector {conn_index}")
    askContinue()
    for pin in row_two:
        print(f"------------------------> Pin Under Test : #{pin}")
        Colorlight_I9_V7_2_Platform().build(BlinkyGpio("p",2,pin), do_program=True)
        askContinue()

    print(f"========================[END testing connector 'p'#{conn_index}]============================")

    print("ALL DONE.")
```