### PR TITLE
orangecrab_r0_2: add `-a 0` to dfu command

### DIFF
--- a/amaranth_boards/orangecrab_r0_2.py
+++ b/amaranth_boards/orangecrab_r0_2.py
@@ -124,7 +124,7 @@ class OrangeCrabR0_2Platform(LatticeECP5Platform):
     def toolchain_program(self, products, name):
         dfu_util = os.environ.get("DFU_UTIL", "dfu-util")
         with products.extract("{}.bit".format(name)) as bitstream_filename:
-            subprocess.check_call([dfu_util, "-D", bitstream_filename])
+            subprocess.check_call([dfu_util, "-a 0", "-D", bitstream_filename])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The newer bootloader on the 85F variant exposes two devices. The first one (0) is the bitstream:

Found DFU: [1209:5af0] ver=0101, devnum=51, cfg=1, intf=0, path="3-1", alt=1, name="0x00100000 RISC-V Firmware", serial="UNKNOWN"
Found DFU: [1209:5af0] ver=0101, devnum=51, cfg=1, intf=0, path="3-1", alt=0, name="0x00080000 Bitstream", serial="UNKNOWN"

See also: https://github.com/orangecrab-fpga/orangecrab-hardware/issues/48

Signed-off-by: Daniel Maslowski <info@orangecms.org>