### PR TITLE
blackice_ii: fix incorrect SRAM /CE pin assignment

### DIFF
--- a/amaranth_boards/blackice_ii.py
+++ b/amaranth_boards/blackice_ii.py
@@ -35,7 +35,7 @@ class BlackIceIIPlatform(LatticeICE40Platform):
         ),
 
         SRAMResource(0,
-            cs_n="136", oe_n="29", we_n="120",
+            cs_n="23", oe_n="29", we_n="120",
             a="137 138 139 141 142 42 43 44 73 74 75 76 115 116 117 118 119 78",
             d="136 135 134 130 125 124 122 121 62 61 60 56 55 48 47 45",
             dm_n="24 28",


### PR DESCRIPTION
The /CE pin was assigned incorrectly (136 instead of 23), also pin 136 was assigned twice, so the SRAMResource failed to instantiate at all.

Fixed version was tested successfully with HW.