### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,19 +3,27 @@ on:
   pull_request:
   schedule:
   - cron: '0 0 * * *' # test daily against git HEAD of dependencies
+
 name: CI
 jobs:
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version:
         - '3.8'
+        - '3.9'
+        - '3.10'
+        - '3.11'
+        - 'pypy-3.8'
+        - 'pypy-3.9'
         # this version range needs to be synchronized with the one in pyproject.toml
         amaranth-version:
         - '0.3'
         - 'git'
       fail-fast: false
+    name: 'test (${{ matrix.python-version }}, ${{ matrix.amaranth-version }})'
     steps:
       - name: Check out source code
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ description = "Board and connector definitions for Amaranth HDL"
 authors = [{name = "Amaranth HDL contributors"}]
 license = {file = "LICENSE.txt"}
 
+requires-python = "~=3.8"
 dependencies = [
-  "importlib_metadata; python_version<'3.8'",
   # this version requirement needs to be synchronized with the one in .github/workflows/main.yml
   "amaranth>=0.3,<0.5",
 ]


### PR DESCRIPTION
Also, expand the Python CI version range to be the same as that of Amaranth.