### PR TITLE
Add PDM development workflow that integrates YoWASP toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
 # Python
-*.pyc
-/*.egg-info
-/.eggs
+__pycache__/
+*.egg-info
 /dist
+
+# pdm
+/.pdm-plugins
+/.pdm-python
+/.venv
+/pdm.lock
 
 # misc user-created
 /build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["wheel", "setuptools~=67.0", "setuptools_scm[toml]>=6.2"]
-build-backend = "setuptools.build_meta"
-
 [project]
 dynamic = ["version"]
 
@@ -20,6 +16,12 @@ dependencies = [
 "Source Code" = "https://github.com/amaranth-lang/amaranth-boards"
 "Bug Tracker" = "https://github.com/amaranth-lang/amaranth-boards/issues"
 
+# Build system configuration
+
+[build-system]
+requires = ["wheel", "setuptools~=67.0", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
 [tool.setuptools]
 # If old amaranth-boards is checked out with git (e.g. as a part of a persistent editable install
 # or a git worktree cached by tools like poetry), it can have an empty `nmigen_boards` directory
@@ -29,3 +31,17 @@ packages = ["amaranth_boards"]
 
 [tool.setuptools_scm]
 local_scheme = "node-and-timestamp"
+
+# Development workflow configuration
+
+[tool.pdm.dev-dependencies]
+toolchain = [
+  "amaranth-yosys",
+  "yowasp-yosys",
+  "yowasp-nextpnr-ice40",
+  "yowasp-nextpnr-ecp5",
+  "yowasp-nextpnr-gowin",
+]
+
+[tool.pdm.scripts]
+_.env_file = ".env.toolchain"


### PR DESCRIPTION
This can simplify smoke testing of boards supported by the FOSS toolchains.

Testing a board with an iCE40, ECP5, etc FPGA is now as simple as:

    pdm install --dev
    pdm run python -m amaranth_boards.board_name

It is not necessary to install a toolchain, set several environment variables, or do anything else.