### PR TITLE
Add smoke tests for a selection of iCE40, ECP5, Gowin, Xilinx boards

### DIFF
--- a/.env.toolchain
+++ b/.env.toolchain
@@ -4,4 +4,3 @@ NEXTPNR_ICE40=yowasp-nextpnr-ice40
 ICEPACK=yowasp-icepack
 NEXTPNR_ECP5=yowasp-nextpnr-ecp5
 ECPPACK=yowasp-ecppack
-NEXTPNR_GOWIN=yowasp-nextpnr-gowin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,19 +42,19 @@ jobs:
       - name: Install Amaranth release
         if: ${{ matrix.amaranth-version != 'git' }}
         run: |
-          pip install 'amaranth==${{ matrix.amaranth-version }}'
+          pip install 'amaranth[builtin-yosys] ==${{ matrix.amaranth-version }}'
       - name: Install Amaranth from git
         if: ${{ matrix.amaranth-version == 'git' }}
         run: |
-          pip install git+https://github.com/amaranth-lang/amaranth.git
-      - name: Test
+          pip install 'amaranth[builtin-yosys] @ git+https://github.com/amaranth-lang/amaranth.git'
+      - name: Run tests
         run: |
           python -m unittest discover -t . -s amaranth_boards -p '*.py'
 
-  required: # group all required workflows into one for the required status check
+  required: # group all required workflows into one to avoid reconfiguring this in Actions settings
     needs:
       - test
+    if: ${{ always() && !contains(needs.*.result, 'cancelled') }}
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          true
+      - run: ${{ contains(needs.*.result, 'failure') && 'false' || 'true' }}

--- a/amaranth_boards/arty_a7.py
+++ b/amaranth_boards/arty_a7.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import unittest
 
 from amaranth.build import *
 from amaranth.vendor import XilinxPlatform
@@ -223,6 +224,12 @@ class ArtyA7_35Platform(_ArtyA7Platform):
 
 class ArtyA7_100Platform(_ArtyA7Platform):
     device      = "xc7a100ti"
+
+
+class TestCase(unittest.TestCase):
+    def test_smoke(self):
+        from .test.blinky import Blinky
+        ArtyA7_35Platform().build(Blinky(), do_build=False)
 
 
 if __name__ == "__main__":

--- a/amaranth_boards/de10_nano.py
+++ b/amaranth_boards/de10_nano.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import unittest
 
 from amaranth.build import *
 from amaranth.vendor import IntelPlatform
@@ -88,6 +89,12 @@ class DE10NanoPlatform(IntelPlatform):
             # puts the ARM cores first.
             subprocess.check_call([quartus_pgm, "--haltcc", "--mode", "JTAG",
                                    "--operation", "P;" + bitstream_filename + "@2"])
+
+
+class TestCase(unittest.TestCase):
+    def test_smoke(self):
+        from .test.blinky import Blinky
+        DE10NanoPlatform().build(Blinky(), do_build=False)
 
 
 if __name__ == "__main__":

--- a/amaranth_boards/ice40_hx8k_b_evn.py
+++ b/amaranth_boards/ice40_hx8k_b_evn.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import unittest
 
 from amaranth.build import *
 from amaranth.vendor import LatticeICE40Platform
@@ -63,6 +64,12 @@ class ICE40HX8KBEVNPlatform(LatticeICE40Platform):
             subprocess.check_call([iceprog, "-S", bitstream_filename])
 
 
+class TestCase(unittest.TestCase):
+    def test_smoke(self):
+        from .test.blinky import Blinky
+        ICE40HX8KBEVNPlatform().build(Blinky(), do_build=False)
+
+
 if __name__ == "__main__":
-    from .test.blinky import *
+    from .test.blinky import Blinky
     ICE40HX8KBEVNPlatform().build(Blinky(), do_program=True)

--- a/amaranth_boards/ulx3s.py
+++ b/amaranth_boards/ulx3s.py
@@ -2,6 +2,7 @@ import os
 import argparse
 import subprocess
 import shutil
+import unittest
 
 from amaranth.build import *
 from amaranth.vendor import LatticeECP5Platform
@@ -44,7 +45,7 @@ class _ULX3SPlatform(LatticeECP5Platform):
         Resource("button_right", 0, Pins("H16", dir="i"), Attrs(IO_TYPE="LVCMOS33", PULLMODE="DOWN")),
 
         # FTDI connection.
-        UARTResource(0, 
+        UARTResource(0,
             rx="M1", tx="L4", rts="M3", dtr="N1", role="dce",
             attrs=Attrs(IO_TYPE="LVCMOS33")
         ),
@@ -103,7 +104,7 @@ class _ULX3SPlatform(LatticeECP5Platform):
         Resource("diff_gpio", 1, DiffPairs("A10", "A11"), Attrs(IO_TYPE="LVCMOS33")),
         Resource("diff_gpio", 2, DiffPairs("A9", "B10"), Attrs(IO_TYPE="LVCMOS33")),
         Resource("diff_gpio", 3, DiffPairs("B9", "C10"),  Attrs(IO_TYPE="LVCMOS33")),
-        
+
         # HDMI (only TX, due to the top bank of ECP5 only supporting diff. outputs)
         Resource("hdmi", 0,
             Subsignal("cec", Pins("A18", dir="io"),
@@ -177,16 +178,22 @@ class ULX3S_85F_Platform(_ULX3SPlatform):
     device                 = "LFE5U-85F"
 
 
+class TestCase(unittest.TestCase):
+    def test_smoke(self):
+        from .test.blinky import Blinky
+        ULX3S_45F_Platform().build(Blinky(), do_build=False)
+
+
 if __name__ == "__main__":
     from .test.blinky import *
-    
+
     variants = {
         '12F': ULX3S_12F_Platform,
         '25F': ULX3S_25F_Platform,
         '45F': ULX3S_45F_Platform,
         '85F': ULX3S_85F_Platform
     }
-    
+
     # Figure out which FPGA variant we want to target...
     parser = argparse.ArgumentParser()
     parser.add_argument('variant', choices=variants.keys())

--- a/amaranth_boards/versa_ecp5.py
+++ b/amaranth_boards/versa_ecp5.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import unittest
 
 from amaranth.build import *
 from amaranth.vendor import LatticeECP5Platform
@@ -171,6 +172,12 @@ class VersaECP5Platform(LatticeECP5Platform):
             ])
 
 
+class TestCase(unittest.TestCase):
+    def test_smoke(self):
+        from .test.blinky import Blinky
+        VersaECP5Platform().build(Blinky(), do_build=False)
+
+
 if __name__ == "__main__":
-    from .test.blinky import *
+    from .test.blinky import Blinky
     VersaECP5Platform().build(Blinky(), do_program=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ toolchain = [
   "yowasp-yosys",
   "yowasp-nextpnr-ice40",
   "yowasp-nextpnr-ecp5",
-  "yowasp-nextpnr-gowin",
 ]
 
 [tool.pdm.scripts]
 _.env_file = ".env.toolchain"
+test.cmd = "python -m unittest discover -t . -s amaranth_boards -p *.py"


### PR DESCRIPTION
The purpose of these tests is just to ensure that Amaranth changes do not blatantly break the boards repository. They are not intended to exhaustively test even a single board.

(The tests currently all fail on Amaranth main branch. This is expected.)