### PR TITLE
Split Arty S7 25 and 50 mains.

### DIFF
--- a/amaranth_boards/arty_s7.py
+++ b/amaranth_boards/arty_s7.py
@@ -228,8 +228,3 @@ class ArtyS7_50Platform(_ArtyS7Platform):
 
 class ArtyS7_25Platform(_ArtyS7Platform):
     device      = "xc7s25"
-
-
-if __name__ == "__main__":
-    from .test.blinky import *
-    ArtyS7_25Platform().build(Blinky(), do_program=True)

--- a/amaranth_boards/arty_s7_25.py
+++ b/amaranth_boards/arty_s7_25.py
@@ -1,0 +1,6 @@
+from .arty_s7 import ArtyS7_25Platform
+
+
+if __name__ == "__main__":
+    from .test.blinky import *
+    ArtyS7_25Platform().build(Blinky(), do_program=True)

--- a/amaranth_boards/arty_s7_50.py
+++ b/amaranth_boards/arty_s7_50.py
@@ -1,0 +1,6 @@
+from .arty_s7 import ArtyS7_50Platform
+
+
+if __name__ == "__main__":
+    from .test.blinky import *
+    ArtyS7_50Platform().build(Blinky(), do_program=True)


### PR DESCRIPTION
# Before

Running
```sh
python3 -m amaranth_boards.arty_s7
```
defaults to S7 25. When run against an S7 50 the flashing process succeeds, but the LEDs never turn on.

# After

User has to explicitly specify an S7 version with:
```sh
python3 -m amaranth_boards.arty_s7_25
```
or
```sh
python3 -m amaranth_boards.arty_s7_50
```

Both `ArtyS7_25Platform` and `ArtyS7_50Platform` are still available for import from `amaranth_boards.arty_s7`.