### PR TITLE
Migrate to the PDM build system

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,0 @@
-node: $Format:%H$
-node-date: $Format:%cI$
-describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
-ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-.git_archival.txt export-subst

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,11 +34,11 @@ jobs:
     name: "test (${{ matrix.python-version }}, ${{ matrix.amaranth-version }}${{ matrix.allow-failure == 'false' && ', required' || '' }})"
     steps:
       - name: Check out source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up PDM
-        uses: pdm-project/setup-pdm@v3
+        uses: pdm-project/setup-pdm@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,10 +35,15 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
+        with:
+          fetch-depth: 0
+      - name: Set up PDM
+        uses: pdm-project/setup-pdm@v3
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pdm install --dev
       - name: Install Amaranth release
         if: ${{ matrix.amaranth-version != 'git' }}
         run: |
@@ -49,7 +54,7 @@ jobs:
           pip install 'amaranth[builtin-yosys] @ git+https://github.com/amaranth-lang/amaranth.git'
       - name: Run tests
         run: |
-          python -m unittest discover -t . -s amaranth_boards -p '*.py'
+          pdm run test
 
   required: # group all required workflows into one to avoid reconfiguring this in Actions settings
     needs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+# Project metadata
+
+[tool.pdm.version]
+source = "scm"
+
 [project]
 dynamic = ["version"]
 
@@ -19,18 +24,8 @@ dependencies = [
 # Build system configuration
 
 [build-system]
-requires = ["wheel", "setuptools>=67.0", "setuptools_scm[toml]>=6.2"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools]
-# If old amaranth-boards is checked out with git (e.g. as a part of a persistent editable install
-# or a git worktree cached by tools like poetry), it can have an empty `nmigen_boards` directory
-# left over, which causes a hard error because setuptools cannot determine the top-level package.
-# Add a workaround to improve experience for people upgrading from old checkouts.
-packages = ["amaranth_boards"]
-
-[tool.setuptools_scm]
-local_scheme = "node-and-timestamp"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
 # Development workflow configuration
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-from setuptools import setup
-
-
-setup()


### PR DESCRIPTION
Migrate to the PDM build system. Avoids problems with .git_archival.txt breaking reproducibility.

Nabbed from https://github.com/amaranth-lang/amaranth-soc/commit/d66881d83419c689fc96168150e57d9f467723aa

Also take the opportunity to update actions to fix the deprecation warnings.