### PR TITLE
Speculatively mark as compatible with Amaranth 0.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
         # this version range needs to be synchronized with the one in pyproject.toml
         amaranth-version:
         - '0.4'
+        - '0.5'
         - 'git'
         allow-failure:
         - true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = {file = "LICENSE.txt"}
 requires-python = "~=3.8"
 dependencies = [
   # this version requirement needs to be synchronized with the one in .github/workflows/main.yml
-  "amaranth>=0.4,<0.6",
+  "amaranth>=0.4,<0.7",
 ]
 
 [project.urls]


### PR DESCRIPTION
We don't currently plan any changes that will break board definitions in the next release.