### PR TITLE
Correct UART pinout for cmod_s7.

### DIFF
--- a/amaranth_boards/cmod_s7.py
+++ b/amaranth_boards/cmod_s7.py
@@ -34,7 +34,7 @@ class CmodS7_Platform(XilinxPlatform):
         *ButtonResources(pins="D2 D1", attrs=Attrs(IOSTANDARD="LVCMOS33")),
 
         UARTResource(0,
-            rx="L12", tx="K15",
+            rx="K15", tx="L12",
             attrs=Attrs(IOSTANDARD="LVCMOS33")
         ),
 


### PR DESCRIPTION
At the very least, I couldn't get any output from a demo using the UART until I made this change. I think the pins were reversed thanks to a potentially [confusing comment](https://github.com/Digilent/Cmod-S7-25-OOB/blob/master/src/constraints/Cmod-S7-25-Master.xdc#L36-L38) from Digilent's XDC for the board.